### PR TITLE
Fix example link and change deploy pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ deploy:
   cache_control: "max-age=31536000"
   on:
     repo: prestwick/webvi-squeeze-page
-    tags: true 
+    brach: master

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ mixpanel.init("61d63d3f2a3631a5cf699e8eea182e98");</script><!-- end Mixpanel -->
       </div>
       <div class="column-container content-duo content-text content-text-a">
         <h2>I/O for IoT</h2>
-        <div>NI Data Services</div>
+        <div><a class="track" href="http://www.systemlinkcloud.com">Cloud Hosted Data Services</a></div>
         <div>LabVIEW HTTP Client</div>
       </div>
     </div>
@@ -167,8 +167,9 @@ mixpanel.init("61d63d3f2a3631a5cf699e8eea182e98");</script><!-- end Mixpanel -->
     <div class="column-container footer-container">
       <h2>Products</h2>
       <div><a class="track" href="http://www.ni.com/en-us/shop/labview/labview-nxg.html">LabVIEW NXG</a></div>
-      <div><a class="track" href="https://github.com/ni/VireoSDK">VireoSDK on Github</a></div>
       <div><a class="track" href="http://www.ni.com/en-us/landing/systems-management-software.html">SystemLink</a></div>
+      <div><a class="track" href="http://www.systemlinkcloud.com">SystemLink Cloud</a></div>
+      <div><a class="track" href="https://github.com/ni/VireoSDK">VireoSDK on Github</a></div>
     </div>
     <div class="column-container footer-container">
       <h2>Examples</h2>

--- a/index.html
+++ b/index.html
@@ -168,10 +168,11 @@ mixpanel.init("61d63d3f2a3631a5cf699e8eea182e98");</script><!-- end Mixpanel -->
       <h2>Products</h2>
       <div><a class="track" href="http://www.ni.com/en-us/shop/labview/labview-nxg.html">LabVIEW NXG</a></div>
       <div><a class="track" href="https://github.com/ni/VireoSDK">VireoSDK on Github</a></div>
-      <div><a class="track" href="http://www.ni.com/en-us/landing/systems-management-software.html">System Link</a></div>
+      <div><a class="track" href="http://www.ni.com/en-us/landing/systems-management-software.html">SystemLink</a></div>
     </div>
     <div class="column-container footer-container">
       <h2>Examples</h2>
+      <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/CallSystemLinkDataServices">Call SystemLink Data Services</a></div>
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/CallLabVIEWWebService">Call LabVIEW Web Service</a></div>
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/Call3rdPartyWebService">Call 3rd Party Web Service</a></div>
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/CustomizeWithCss">Customize with CSS</a></div>
@@ -179,7 +180,6 @@ mixpanel.init("61d63d3f2a3631a5cf699e8eea182e98");</script><!-- end Mixpanel -->
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/EmbedWebVIIntoContent">Embed a WebVI into Content</a></div>
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/IncorporateUserResources">Incorporate User Resources</a></div>
       <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/MultipleTopLevelWebVIs">Multiple Top Level WebVIs</a></div>
-      <div><a class="track" href="https://github.com/ni/webvi-examples/tree/master/UtilizeSkylineDataServices">Utilize Skyline Data Services</a></div>
     </div>
     <div class="column-container footer-container">
       <h2><a class="track" href="http://www.ni.com">NI</a></h2>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "webvi-squeeze-page",
   "jshint-stylish": "^0.4.0",
-  "version": "0.13.3"
+  "version": "0.13.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "webvi-squeeze-page",
   "jshint-stylish": "^0.4.0",
-  "version": "0.13.2"
+  "version": "0.13.3"
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,3 +7,8 @@ mixpanel.track_links(".track", "link clicked", {
 mixpanel.track_links(".nav-track", "nav clicked", {
     "tier": window.location.hostname
 });
+
+//track page views
+mixpanel.track("page-view", {
+    "tier": window.location.hostname
+});


### PR DESCRIPTION
- Linking to Call SystemLink Examples (name of this example had changed)
- Changed link text from "System Link" to "SystemLink"
- Added a link to SystemLink Cloud
- Change deployment to occur when committing to master rather than with tagging to make deployment more accessible to marketing
- add a `page-view` tracking event for mixpanel